### PR TITLE
fix: LDAP-14 implementando validação de parâmetros na URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,10 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -72,4 +76,17 @@
 		</plugins>
 	</build>
 
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
 </project>

--- a/src/main/java/com/ldap_service/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ldap_service/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.ldap.InvalidNameException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -35,5 +36,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInvalidNameException(InvalidNameException ex) {
         ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+    
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 }

--- a/src/main/java/com/ldap_service/person/PersonController.java
+++ b/src/main/java/com/ldap_service/person/PersonController.java
@@ -20,7 +20,21 @@ public class PersonController {
 
 	@Autowired
 	private PersonService personService;
-
+	
+	//TODO: 1°
+	//TODO: Mantido para validar parâmetros na URL.
+	//TODO: Exemplo lançando status: 400 
+	//TODO: Passando ""(aspas duplas) na URL: http://localhost:8080/api/v1/personas/""/filtro
+	//TODO: Passando ''(aspas simples) na URL: http://localhost:8080/api/v1/personas/''/filtro
+	//TODO: Passando null(null) na URL: http://localhost:8080/api/v1/personas/null/filtro
+    @PostMapping("/{sn}/filtro")
+    public ResponseEntity<String> filtro(@PathVariable(required = false) String sn) {
+//    	if (sn == null || sn.trim().isEmpty()) {
+//            throw new BadRequestException("O parâmetro 'texto' não pode ser nulo ou vazio.");
+//        }
+        return new ResponseEntity<>("Filtro realizado com sucesso!", HttpStatus.OK);
+    }
+	
 	@GetMapping
 	public List<PersonResponse> findAll() {
 		return personService.findAll().stream().map(PersonDTO::toResponse).toList();
@@ -35,7 +49,7 @@ public class PersonController {
 	public ResponseEntity<Person> create(@RequestBody PersonRequest personRequest) {
 		return ResponseEntity.ok(personService.create(personRequest.toDTO()));
 	}
-
+	
 	@PutMapping("/{username}/password")
 	public ResponseEntity<String> updatePassword(@PathVariable String username, @RequestBody String password) {
 		try {

--- a/src/main/java/com/ldap_service/validation/PathValidationFilter.java
+++ b/src/main/java/com/ldap_service/validation/PathValidationFilter.java
@@ -1,0 +1,61 @@
+package com.ldap_service.validation;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+//TODO: 2°
+@Component
+public class PathValidationFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+			throws ServletException, IOException {
+
+		String path = request.getRequestURI();
+
+		// Decodificar a URL para pegar os valores corretos
+		String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+
+		// Extrair a parte do path que contém o "texto"
+		String[] pathParts = decodedPath.split("/");
+		if (pathParts.length >= 5) { // considerando a estrutura /api/v1/personas/{texto}/filtro
+			String texto = pathParts[4]; // O valor do PathVariable "texto"
+			
+			 if (texto == null || texto.trim().isEmpty() || texto.equals("''") || texto.equals("\"\"")
+	                    || texto.equalsIgnoreCase("null")) {
+	                // Criar a estrutura de erro personalizada
+	                List<Map<String, Object>> errors = new ArrayList<>();
+	                Map<String, Object> error = new HashMap<>();
+	                error.put("codigo", HttpStatus.BAD_REQUEST.value());
+	                error.put("mensagem", "O parâmetro 'texto' não pode ser vazio, inválido ou 'null'.");
+	                errors.add(error);
+
+	                // Configurar a resposta
+	                response.setStatus(HttpStatus.BAD_REQUEST.value());
+	                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+	                response.setCharacterEncoding("UTF-8");
+	                response.getWriter().write(new ObjectMapper().writeValueAsString(Map.of("errors", errors)));
+	                return;
+	            }
+		}
+
+		filterChain.doFilter(request, response); // Continua a execução se estiver correto
+	}
+}


### PR DESCRIPTION
Realizado tratamento para resultar nos seguintes **comportamentos esperados** para as seguintes **URLs**:

  - /api/v1/personas/""/filtro — Retorna 400 Bad Request porque as aspas duplas são inválidas.
  - /api/v1/personas/''/filtro — Retorna 400 Bad Request porque as aspas simples são inválidas.
  - /api/v1/personas/null/filtro — Agora também retornará 400 Bad Request, pois a palavra null é tratada como inválida.
  - /api/v1/personas/validText/filtro — Continua funcionando normalmente com um 200 OK.

**Conclusão:**

Com essa última alteração, o filtro agora intercepta e valida corretamente tanto valores vazios, como "" ou '', quanto a palavra "null". Agora, todos esses casos devem ser tratados como Bad Request (400).
